### PR TITLE
Fixed a typo in the Let's Encrypt section

### DIFF
--- a/cv04-apache/manual.md
+++ b/cv04-apache/manual.md
@@ -175,6 +175,6 @@ Nginx config
 
 ```
         location /.well-known/acme-challenge {
-            alias   /var/www/letsencrypt/.well-known/acme-challenge;
+            alias   /var/www/dehydrated/.well-known/acme-challenge;
         }
 ```


### PR DESCRIPTION
- there was an incorrect nginx alias config that pointed to a non-existing directory
    - the alias should point to the directory in which `dehydrated` stores challenges 